### PR TITLE
add browser support via umd pattern

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -11,5 +11,9 @@
   "boss": true,
   "eqnull": true,
   "node": true,
-  "es5": true
+  "es5": true,
+  "globals": {
+    "define": false,
+    "window": false
+  }
 }

--- a/lib/getobject.js
+++ b/lib/getobject.js
@@ -8,53 +8,66 @@
 
 'use strict';
 
-var getobject = module.exports = {};
+(function (factory) {
+  var moduleName = 'getobject';
+  if (typeof define === 'function' && define.amd) {
+    define([], factory);
+  } else if (typeof exports === 'object') {
+    module.exports = factory();
+  } else {
+    window[moduleName] = factory();
+  }
+}(function () {
+  var getobject = {};
 
-// Split strings on dot, but only if dot isn't preceded by a backslash. Since
-// JavaScript doesn't support lookbehinds, use a placeholder for "\.", split
-// on dot, then replace the placeholder character with a dot.
-function getParts(str) {
-  return str.replace(/\\\./g, '\uffff').split('.').map(function(s) {
-    return s.replace(/\uffff/g, '.');
-  });
-}
-
-// Get the value of a deeply-nested property exist in an object.
-getobject.get = function(obj, parts, create) {
-  if (typeof parts === 'string') {
-    parts = getParts(parts);
+  // Split strings on dot, but only if dot isn't preceded by a backslash. Since
+  // JavaScript doesn't support lookbehinds, use a placeholder for "\.", split
+  // on dot, then replace the placeholder character with a dot.
+  function getParts(str) {
+    return str.replace(/\\\./g, '\uffff').split('.').map(function(s) {
+      return s.replace(/\uffff/g, '.');
+    });
   }
 
-  var part;
-  while (typeof obj === 'object' && obj && parts.length) {
-    part = parts.shift();
-    if (!(part in obj) && create) {
-      obj[part] = {};
+  // Get the value of a deeply-nested property exist in an object.
+  getobject.get = function(obj, parts, create) {
+    if (typeof parts === 'string') {
+      parts = getParts(parts);
     }
-    obj = obj[part];
-  }
 
-  return obj;
-};
+    var part;
+    while (typeof obj === 'object' && obj && parts.length) {
+      part = parts.shift();
+      if (!(part in obj) && create) {
+        obj[part] = {};
+      }
+      obj = obj[part];
+    }
 
-// Set a deeply-nested property in an object, creating intermediary objects
-// as we go.
-getobject.set = function(obj, parts, value) {
-  parts = getParts(parts);
+    return obj;
+  };
 
-  var prop = parts.pop();
-  obj = getobject.get(obj, parts, true);
-  if (obj && typeof obj === 'object') {
-    return (obj[prop] = value);
-  }
-};
+  // Set a deeply-nested property in an object, creating intermediary objects
+  // as we go.
+  getobject.set = function(obj, parts, value) {
+    parts = getParts(parts);
 
-// Does a deeply-nested property exist in an object?
-getobject.exists = function(obj, parts) {
-  parts = getParts(parts);
+    var prop = parts.pop();
+    obj = getobject.get(obj, parts, true);
+    if (obj && typeof obj === 'object') {
+      return (obj[prop] = value);
+    }
+  };
 
-  var prop = parts.pop();
-  obj = getobject.get(obj, parts);
+  // Does a deeply-nested property exist in an object?
+  getobject.exists = function(obj, parts) {
+    parts = getParts(parts);
 
-  return typeof obj === 'object' && obj && prop in obj;
-};
+    var prop = parts.pop();
+    obj = getobject.get(obj, parts);
+
+    return typeof obj === 'object' && obj && prop in obj;
+  };
+
+  return getobject;
+}));


### PR DESCRIPTION
Wrapped in a modified [UMD.js 'returnExports' pattern](https://github.com/umdjs/umd/blob/master/returnExports.js) for browser support, while maintaining jshint pass.
