### PR TITLE
Remove non-essential files from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
     "set",
     "object",
     "dot"
+  ],
+  "files": [
+    "lib"
   ]
 }


### PR DESCRIPTION
LICENSE and README files are included by default.